### PR TITLE
txpool/pool.go: change log level to dbug

### DIFF
--- a/txpool/pool.go
+++ b/txpool/pool.go
@@ -1785,7 +1785,7 @@ func (p *TxPool) logStats() {
 		ctx = append(ctx, "cache_keys", cacheKeys)
 	}
 	ctx = append(ctx, "alloc", common.ByteCount(m.Alloc), "sys", common.ByteCount(m.Sys))
-	log.Info("[txpool] stat", ctx...)
+	log.Debug("[txpool] stat", ctx...)
 	pendingSubCounter.Set(uint64(p.pending.Len()))
 	basefeeSubCounter.Set(uint64(p.baseFee.Len()))
 	queuedSubCounter.Set(uint64(p.queued.Len()))


### PR DESCRIPTION
We don't need txpool log , so  change log level to dbug
See this issue:https://github.com/node-real/bsc-erigon/issues/69